### PR TITLE
feat: Increase ECS memory and Lambda timeout

### DIFF
--- a/gemini-cli/ops-chat/README.md
+++ b/gemini-cli/ops-chat/README.md
@@ -7,20 +7,17 @@ gemini --yolo --checkpointing
 
 ### Prompt 1.
 ```
-查看 ECS gemini-cli-cluster region ap-east-2, ECS Service 跟 task 以及 event 狀態如何？ aws profile 使用 neil (思考過程跟，使用的 tools，分析結果記錄在 RECORD.md）
-
-/chat save ecs
+查看 ECS gemini-cli-cluster region ap-east-2, ECS Service 跟 task 以及 event 狀態如何？ aws profile 使用 neil (思考過程跟，使用的 tools，分析結果記錄在 RECORD.ecs.md）
 ```
 
 ### Prompt 2.
 ```
-cd gemini-cli/ops-code
+cd gemini-cli
 gemini --yolo --checkpointing
 
-/chat resume ecs
 ```
 ```
-修復剛剛的問題，當下資料夾為部署剛剛 ECS Cluster 的 CDK code 。
+讀取 ops-chat/RECORD.ecs.md 修復遇到的問題，當下資料夾 ops-code 為部署剛剛 ECS Cluster 的 CDK code ， aws profile 使用 neil，並將修改過程記錄在  ops-code/RECORD.ecs.fix.md。(你可以 cd 到 ops-code 來進行部署）。
 ```
 
 ### Invoke Lambda Function
@@ -35,18 +32,21 @@ cd gemini-cli/ops-chat
 gemini --yolo --checkpointing
 ```
 ```
-查看 Lambda Function gemini-cli-lambda 最近幾次的執行狀態如何？ aws profile 使用 neil region ap-east-2 (思考過程跟，使用的 tools，分析結果記錄在 RECORD.md）
+查看 Lambda Function gemini-cli-lambda 最近幾次的執行狀態如何？ aws profile 使用 neil region ap-east-2 (思考過程跟，使用的 tools，分析結果記錄在 RECORD.lambda.md）
 
-/chat save lambda
 ```
 
 ### Prompt 4.
 ```
-cd gemini-cli/ops-code
+cd gemini-cli
 gemini --yolo --checkpointing
 
-/chat resume lambda
 ```
 ```
-修復剛剛的問題，當下資料夾為部署剛剛 Lambda Function 的 CDK code ，如果要部署請告訴我。
+讀取 ops-chat/RECORD.lambda.md 修復遇到的問題，當下資料夾 ops-code 為部署剛剛 Lambda Function 的 CDK code ， aws profile 使用 neil，並將修改過程記錄在  ops-code/RECORD.lambda.fix.md。(你可以 cd 到 ops-code 來進行部署）。
+```
+
+### Prompt 5.
+```
+根據  RECORD.lambda.fix.md 以及 RECORD.ecs.fix.md，原因過程結果發一個 PR 到 main branch 使用 github mcp。
 ```

--- a/gemini-cli/ops-chat/RECORD.ecs.md
+++ b/gemini-cli/ops-chat/RECORD.ecs.md
@@ -1,0 +1,712 @@
+{
+    "serviceArns": [
+        "arn:aws:ecs:ap-east-2:807885433112:service/gemini-cli-cluster/gemini-cli-service"
+    ]
+}
+
+
+---
+
+## ECS Service Details
+
+{
+    "services": [
+        {
+            "serviceArn": "arn:aws:ecs:ap-east-2:807885433112:service/gemini-cli-cluster/gemini-cli-service",
+            "serviceName": "gemini-cli-service",
+            "clusterArn": "arn:aws:ecs:ap-east-2:807885433112:cluster/gemini-cli-cluster",
+            "loadBalancers": [],
+            "serviceRegistries": [],
+            "status": "ACTIVE",
+            "desiredCount": 1,
+            "runningCount": 1,
+            "pendingCount": 0,
+            "launchType": "EC2",
+            "taskDefinition": "arn:aws:ecs:ap-east-2:807885433112:task-definition/gemini-cli-task-def:4",
+            "deploymentConfiguration": {
+                "deploymentCircuitBreaker": {
+                    "enable": false,
+                    "rollback": false
+                },
+                "maximumPercent": 200,
+                "minimumHealthyPercent": 50,
+                "strategy": "ROLLING",
+                "bakeTimeInMinutes": 0
+            },
+            "deployments": [
+                {
+                    "id": "ecs-svc/7610517791682758113",
+                    "status": "PRIMARY",
+                    "taskDefinition": "arn:aws:ecs:ap-east-2:807885433112:task-definition/gemini-cli-task-def:4",
+                    "desiredCount": 1,
+                    "pendingCount": 0,
+                    "runningCount": 1,
+                    "failedTasks": 0,
+                    "createdAt": "2025-09-03T08:56:24.276000+08:00",
+                    "updatedAt": "2025-09-03T10:04:50.421000+08:00",
+                    "launchType": "EC2",
+                    "networkConfiguration": {
+                        "awsvpcConfiguration": {
+                            "subnets": [
+                                "subnet-0ae4088933d2b01c9",
+                                "subnet-0c0eba6d4fb81bd0b",
+                                "subnet-0484269876e7bb12a"
+                            ],
+                            "securityGroups": [
+                                "sg-0ba17f946c3fa9b95"
+                            ],
+                            "assignPublicIp": "DISABLED"
+                        }
+                    },
+                    "rolloutState": "COMPLETED",
+                    "rolloutStateReason": "ECS deployment ecs-svc/7610517791682758113 completed."
+                }
+            ],
+            "roleArn": "arn:aws:iam::807885433112:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+            "events": [
+                {
+                    "id": "bb2949d2-89f7-48d1-8e02-91faadba1eda",
+                    "createdAt": "2025-09-03T10:04:50.427000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "5f863504-0a65-4515-b5f4-1deed8b260f0",
+                    "createdAt": "2025-09-03T10:04:31.404000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task b23e2cd65a99432190bd640cac2229b5)."
+                },
+                {
+                    "id": "ba70d7d2-9e9e-4b5f-bfde-2e04fd9748dd",
+                    "createdAt": "2025-09-03T10:04:00.697000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "5bba4fb3-7b36-4014-ab77-844867f7ecd5",
+                    "createdAt": "2025-09-03T10:03:41.448000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 5b30fffff37440d1a03c6fbddb1909ce)."
+                },
+                {
+                    "id": "142d830f-aaa1-41e8-9f93-87c5b728b95b",
+                    "createdAt": "2025-09-03T10:03:11.187000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "55ef2b82-07bd-46ae-8af5-8ce3820a452b",
+                    "createdAt": "2025-09-03T10:02:51.784000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task b3ef0198c7324aa58dc0bc2236041e5e)."
+                },
+                {
+                    "id": "d6864483-8551-4ffc-b01b-3357384bb898",
+                    "createdAt": "2025-09-03T10:02:21.846000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "a5f86c0c-d870-4da1-8d2d-e89a9b7ac813",
+                    "createdAt": "2025-09-03T10:02:03.183000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 21dbe4a973ae46a680662e5124a1a6b9)."
+                },
+                {
+                    "id": "19e24acb-54e9-4639-ac0e-549c2fb48f54",
+                    "createdAt": "2025-09-03T10:01:31.173000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "83a1e18c-7bf7-4ab2-9144-72da19b79240",
+                    "createdAt": "2025-09-03T10:01:12.276000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task e7a9aaeb2f594bed938226a5c38e75fd)."
+                },
+                {
+                    "id": "e773dff0-f4a0-4e87-9968-acec9c403f9b",
+                    "createdAt": "2025-09-03T10:00:42.352000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "ad9d6425-3ab4-43e5-abab-b6e50acfb19e",
+                    "createdAt": "2025-09-03T10:00:23.204000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 45b43fe70fa144d68943d4552bb1daf4)."
+                },
+                {
+                    "id": "151bb7da-601b-48ec-83e1-c8e9fc50e192",
+                    "createdAt": "2025-09-03T09:59:53.849000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "ee49cdff-284e-4fa7-8e72-dd2e16e47e44",
+                    "createdAt": "2025-09-03T09:59:34.799000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task af09c66bd8584b95b92d51453c78a1a1)."
+                },
+                {
+                    "id": "3f60c369-2a04-4b44-a9f4-7ee2a5ca151f",
+                    "createdAt": "2025-09-03T09:59:02.964000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "08505ced-5a24-420a-a37d-3cfbd9cceeae",
+                    "createdAt": "2025-09-03T09:58:44.070000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task fda08e2cfb8e4e7a8f6f24099396efa6)."
+                },
+                {
+                    "id": "1c30fa7a-8255-40cb-bf00-8b474306a390",
+                    "createdAt": "2025-09-03T09:58:13.196000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "67f57ec9-f4c0-4edd-9848-efdfdecec4d8",
+                    "createdAt": "2025-09-03T09:57:54.940000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 7978464620d94b148b0fc82ae4f476a5)."
+                },
+                {
+                    "id": "d71be955-912f-4415-9aab-b1576299b8cd",
+                    "createdAt": "2025-09-03T09:57:23.154000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "fd82be00-35cc-492b-a19b-7f1b29cec391",
+                    "createdAt": "2025-09-03T09:57:04.129000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task eb978cf60a824c268884c2f2647115a6)."
+                },
+                {
+                    "id": "97e9eaad-3888-4664-816f-de7c84590d3b",
+                    "createdAt": "2025-09-03T09:56:32.653000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "da86f7c5-bf94-43ec-a0e7-c81117df0a87",
+                    "createdAt": "2025-09-03T09:56:14.636000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 7af7c689ecf14a6595f969dd5f9e2ddf)."
+                },
+                {
+                    "id": "181b9c99-1cc1-4e01-bf14-e73b951356d2",
+                    "createdAt": "2025-09-03T09:55:45.603000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "9e9e6bda-2d58-42c4-921b-af554add5bd4",
+                    "createdAt": "2025-09-03T09:55:26.077000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task e7cf593b3acb49be90c5ffeec579630a)."
+                },
+                {
+                    "id": "9aa25cec-b2c5-4712-9325-f468fd0b14ae",
+                    "createdAt": "2025-09-03T09:54:55.769000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "75f2dedd-794d-4346-b89d-6a0ad94dcbae",
+                    "createdAt": "2025-09-03T09:54:36.527000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task ba095da198334c63b147416b247b600e)."
+                },
+                {
+                    "id": "817e18c0-8f53-4fe4-945f-2d96f39f8867",
+                    "createdAt": "2025-09-03T09:54:06.684000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "251776cd-68aa-4042-ac2b-5db077ed9280",
+                    "createdAt": "2025-09-03T09:53:47.849000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 875f2313a8b74b87a0c4a7ffee3d682c)."
+                },
+                {
+                    "id": "772b4196-e5ba-4cfc-bf54-1f3c1cab40cc",
+                    "createdAt": "2025-09-03T09:53:16.644000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "104f0dba-0ddd-4d13-a5cd-8e8b123a6144",
+                    "createdAt": "2025-09-03T09:52:58.230000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task fbc2319c116b484b9703f52d713e75f7)."
+                },
+                {
+                    "id": "b7b68316-337e-412f-84ae-fd482ba0130b",
+                    "createdAt": "2025-09-03T09:52:27.047000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "5be8451a-7a24-4bc2-bec8-44ed2f270f39",
+                    "createdAt": "2025-09-03T09:52:08.592000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 22bea5f398be470aa212eda33de000b8)."
+                },
+                {
+                    "id": "c6728715-5e5a-452d-b007-56309326421d",
+                    "createdAt": "2025-09-03T09:51:36.659000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "8ebcb551-f2a8-47b2-a35c-14d5daddeaf7",
+                    "createdAt": "2025-09-03T09:51:17.645000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 0fe8585e49254f2ab57ddf2647a7397c)."
+                },
+                {
+                    "id": "b11e538e-57cb-41bc-905c-0c15816839a3",
+                    "createdAt": "2025-09-03T09:50:47.488000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "d912ccc3-b289-435f-aea8-fc79bfd8d0b4",
+                    "createdAt": "2025-09-03T09:50:28.408000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task bed8dd4b1578434f8464f3fba2fecef6)."
+                },
+                {
+                    "id": "d8268fab-fc94-45a9-b929-fe0242131141",
+                    "createdAt": "2025-09-03T09:49:56.573000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "ad902558-d561-43fc-8307-4568bc06c187",
+                    "createdAt": "2025-09-03T09:49:37.260000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 3d274228237742d88888595d8780b0f2)."
+                },
+                {
+                    "id": "02c31328-bdd3-4687-b53d-3d23974769ff",
+                    "createdAt": "2025-09-03T09:49:05.174000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "b3916446-e019-47e1-a621-f80615edbf88",
+                    "createdAt": "2025-09-03T09:48:46.798000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 4367c401bbc04531b0de5bc651b2d7c1)."
+                },
+                {
+                    "id": "8d08cc2c-1597-4dac-9bd5-43ea0f26f2c6",
+                    "createdAt": "2025-09-03T09:48:15.356000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "41c24bf8-f01c-403d-8adf-b3c1a0168cec",
+                    "createdAt": "2025-09-03T09:47:57.323000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task b890c442bfd14a999067ffd6d90e98d6)."
+                },
+                {
+                    "id": "afdcbe1a-bc1f-4ed1-a543-8eab88bf09f5",
+                    "createdAt": "2025-09-03T09:47:25.549000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "da5897f4-17cf-477c-b6c7-b7eddca4be6c",
+                    "createdAt": "2025-09-03T09:47:06.006000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 926432983b8e41078e8a2baf2b32d42b)."
+                },
+                {
+                    "id": "180f9779-3454-4a1b-8f28-c51d000018fa",
+                    "createdAt": "2025-09-03T09:46:33.717000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "ac1fd96b-f951-4d97-9b6a-0ff961ca915a",
+                    "createdAt": "2025-09-03T09:46:14.423000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 4d11d4ac436d4856a731804197d572e9)."
+                },
+                {
+                    "id": "5133643b-f34c-4c25-aa70-96af9ecea4b3",
+                    "createdAt": "2025-09-03T09:45:43.409000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "cb65959f-b369-4b72-9159-92c0d44503aa",
+                    "createdAt": "2025-09-03T09:45:24.928000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task abcc60be60344e7495cc06c39dd10c56)."
+                },
+                {
+                    "id": "09a09103-95a5-4dbd-89e2-791a47ec2e77",
+                    "createdAt": "2025-09-03T09:44:55.363000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "a2c6f74d-2567-4509-95ff-9b29e91ae15e",
+                    "createdAt": "2025-09-03T09:44:36.278000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 7fc371ba6254475bb583efd52e1a0698)."
+                },
+                {
+                    "id": "058f9d3e-4abd-4780-9779-7202a0c3f209",
+                    "createdAt": "2025-09-03T09:44:05.017000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "808e5987-1474-47df-a4b0-49068f7af6ec",
+                    "createdAt": "2025-09-03T09:43:46.297000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 068fc9acf08445e395f2657de0c61d66)."
+                },
+                {
+                    "id": "93638f41-cb31-44c7-a05f-eec2e7711d5e",
+                    "createdAt": "2025-09-03T09:43:15.197000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "6a18a743-dd63-4e0a-aaaf-372fa0f545b5",
+                    "createdAt": "2025-09-03T09:42:56.253000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task b2f74e4406614fae88ac4c6a9db745bf)."
+                },
+                {
+                    "id": "2cf2f221-5489-4ba1-b1d6-a32ce70e4246",
+                    "createdAt": "2025-09-03T09:42:24.733000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "09f1cfa8-a5c2-47fa-a6cb-eaebc1644bc3",
+                    "createdAt": "2025-09-03T09:42:05.502000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 9ed7749bcfa2469c96c5176ddfe5e3c6)."
+                },
+                {
+                    "id": "a837e57a-8ee6-4b19-bdb7-780f6f57ca26",
+                    "createdAt": "2025-09-03T09:41:33.317000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "10bbe5fd-071f-45e2-934f-10ab30bcb830",
+                    "createdAt": "2025-09-03T09:41:14.137000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task c956f91102bb46bb8116c3e0094bf5ce)."
+                },
+                {
+                    "id": "670fe789-42a4-4a8c-aa79-8be9dbe2fd18",
+                    "createdAt": "2025-09-03T09:40:42.960000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "d87df0ea-88b8-44ec-adff-cd6b56be1688",
+                    "createdAt": "2025-09-03T09:40:24.319000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 82086358b9924ccab8d887648c00f886)."
+                },
+                {
+                    "id": "ad3eeb98-5cf1-4474-abb1-726b014e9474",
+                    "createdAt": "2025-09-03T09:39:53.543000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "f854302f-6672-4111-8f24-f12888ebe796",
+                    "createdAt": "2025-09-03T09:39:33.944000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 37a5bbaf1e3043aaac7b577d70802381)."
+                },
+                {
+                    "id": "a2d2e9e1-b007-42f0-a421-985c852ebad8",
+                    "createdAt": "2025-09-03T09:39:03.018000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "b24fdd4f-1117-4e9d-99ce-9fbb45bcfdb8",
+                    "createdAt": "2025-09-03T09:38:44.043000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 2fdb0877c1924845a00dfdaf78a9e898)."
+                },
+                {
+                    "id": "0cc68d94-381e-4d27-a73b-8ae415ab0d69",
+                    "createdAt": "2025-09-03T09:38:12.366000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "4a345a9f-4857-46be-ab87-e94604d8d954",
+                    "createdAt": "2025-09-03T09:37:53.612000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 6054b4dacf794f4b941d17fc03a7256d)."
+                },
+                {
+                    "id": "1d889b97-0d55-438d-a00c-1c43db8df053",
+                    "createdAt": "2025-09-03T09:37:21.565000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "444fb9c8-d7e3-45e5-afec-9d5acccbb50c",
+                    "createdAt": "2025-09-03T09:37:02.525000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task e62a4d2d3d9141559af1a0a93bd82a63)."
+                },
+                {
+                    "id": "25d0c189-5959-460b-a685-904138531a1a",
+                    "createdAt": "2025-09-03T09:36:31.001000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "f72232db-41bd-4920-8223-9e287fb17930",
+                    "createdAt": "2025-09-03T09:36:12.034000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task a9e6fbfb45c54a06a68fd8886612a7b0)."
+                },
+                {
+                    "id": "23500959-2089-4d4e-9fb0-15a1a500ac02",
+                    "createdAt": "2025-09-03T09:35:42.264000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "4c64bcc3-efc8-4e09-8b5a-e1009af3baed",
+                    "createdAt": "2025-09-03T09:35:22.858000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 4f05e84207764be1b0ca1541ee570df8)."
+                },
+                {
+                    "id": "664caa41-d487-4e16-9de0-b0c4456c0953",
+                    "createdAt": "2025-09-03T09:34:53.276000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "480c6cb3-9ff6-45ae-95ed-82d4234828af",
+                    "createdAt": "2025-09-03T09:34:34.302000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task bd1b04d2c5364c9490511da1b60bc679)."
+                },
+                {
+                    "id": "fa50c8be-975a-4b46-a72e-a8dbf5798c34",
+                    "createdAt": "2025-09-03T09:34:03.440000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "73eb5162-59f1-4031-bc3f-a2e2a8be44f1",
+                    "createdAt": "2025-09-03T09:33:44.068000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 270ffa129f6342359d60ffc86c3b7d57)."
+                },
+                {
+                    "id": "729d97ad-a0d0-41b4-acab-e7a8be48f953",
+                    "createdAt": "2025-09-03T09:33:13.069000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "03497424-7429-45d8-8d29-7bc2241803f7",
+                    "createdAt": "2025-09-03T09:32:53.830000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 789addf69af34419ba0d9b2b675a85e4)."
+                },
+                {
+                    "id": "2024925d-ee59-4631-a19e-d783c6efda98",
+                    "createdAt": "2025-09-03T09:32:22.993000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "dc4fde2b-3df1-4c3a-8013-695299c0e119",
+                    "createdAt": "2025-09-03T09:32:04.593000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task f751d2bbc4674bad931389813317f08b)."
+                },
+                {
+                    "id": "8724fd6d-56a6-4e98-a56f-d9ae805dd1e0",
+                    "createdAt": "2025-09-03T09:31:34.496000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "b18d8ba6-89b9-4443-beb0-d69137737956",
+                    "createdAt": "2025-09-03T09:31:15.850000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task f24b6666ce7b40e1a98b48b80e9f2abe)."
+                },
+                {
+                    "id": "2f836b79-a9e3-4d7c-9ce5-26bbeb2f203b",
+                    "createdAt": "2025-09-03T09:30:45.373000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "d922527a-2977-4320-8981-b7877ad1b519",
+                    "createdAt": "2025-09-03T09:30:25.495000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task a84ceb5ffa424c6ca002dc7d70d4456c)."
+                },
+                {
+                    "id": "4ee6b475-8279-4842-bfe1-7c62da9530d0",
+                    "createdAt": "2025-09-03T09:29:54.992000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "585855a2-47bd-4b7a-9801-6ea21a647cd0",
+                    "createdAt": "2025-09-03T09:29:36.592000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 12865c473b684a3a94afa8f2db4efc9e)."
+                },
+                {
+                    "id": "0cfdd600-55f7-4718-888c-c3605038d5cf",
+                    "createdAt": "2025-09-03T09:29:05.449000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "c6d50f00-d962-4622-ab73-2d29bf6073a2",
+                    "createdAt": "2025-09-03T09:28:46.383000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task beca502f01b142f6b2fd24d6ed623fb2)."
+                },
+                {
+                    "id": "abe48dfa-032b-40f1-ba7d-b4d06eff7cee",
+                    "createdAt": "2025-09-03T09:28:14.492000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "47bb4010-24b7-4520-8bc9-22402129e2d0",
+                    "createdAt": "2025-09-03T09:27:55.433000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task d9f795db50654197b9e6c2fd05bad1e4)."
+                },
+                {
+                    "id": "0c567d92-b036-4a7a-b793-8497db6367f3",
+                    "createdAt": "2025-09-03T09:27:24.559000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "805673af-c519-481a-ab11-0b798db37277",
+                    "createdAt": "2025-09-03T09:27:05.494000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 1aa1d8127b224059b29419a429ef7532)."
+                },
+                {
+                    "id": "96f5c0f0-9110-4701-8790-24b70014b0c1",
+                    "createdAt": "2025-09-03T09:26:35.478000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "945635bb-1072-4ccf-9846-563419ec8652",
+                    "createdAt": "2025-09-03T09:26:15.922000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 27bbd229008442608fcaca240eb4606c)."
+                },
+                {
+                    "id": "7a31d6c0-8140-490c-9255-d1905b64eeb3",
+                    "createdAt": "2025-09-03T09:25:44.798000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "dbc7564e-bc40-4434-9c58-f22521264560",
+                    "createdAt": "2025-09-03T09:25:25.986000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task 9f1bfcfd90f745bd839653ee7439ddff)."
+                },
+                {
+                    "id": "0ba7d6e8-be72-47d1-a0a0-c92a3061d985",
+                    "createdAt": "2025-09-03T09:24:53.917000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "c37192b1-2fbe-49d8-84ab-efde127cc07c",
+                    "createdAt": "2025-09-03T09:24:35.323000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task d919b56d304c4c3ab84c4f36d5b951dc)."
+                },
+                {
+                    "id": "a62d86ba-67b2-4dee-9a74-b94825e2b7ac",
+                    "createdAt": "2025-09-03T09:24:05.623000+08:00",
+                    "message": "(service gemini-cli-service) has reached a steady state."
+                },
+                {
+                    "id": "d7b48de9-ba24-4b91-a396-49d2f564bf8f",
+                    "createdAt": "2025-09-03T09:23:47.134000+08:00",
+                    "message": "(service gemini-cli-service) has started 1 tasks: (task d6d1bc14f4384de1bdaac6e09ef17c7e)."
+                }
+            ],
+            "createdAt": "2025-09-03T08:56:24.276000+08:00",
+            "placementConstraints": [],
+            "placementStrategy": [],
+            "networkConfiguration": {
+                "awsvpcConfiguration": {
+                    "subnets": [
+                        "subnet-0ae4088933d2b01c9",
+                        "subnet-0c0eba6d4fb81bd0b",
+                        "subnet-0484269876e7bb12a"
+                    ],
+                    "securityGroups": [
+                        "sg-0ba17f946c3fa9b95"
+                    ],
+                    "assignPublicIp": "DISABLED"
+                }
+            },
+            "healthCheckGracePeriodSeconds": 0,
+            "schedulingStrategy": "REPLICA",
+            "deploymentController": {
+                "type": "ECS"
+            },
+            "createdBy": "arn:aws:iam::807885433112:role/cdk-hnb659fds-cfn-exec-role-807885433112-ap-east-2",
+            "enableECSManagedTags": false,
+            "propagateTags": "NONE",
+            "enableExecuteCommand": false,
+            "availabilityZoneRebalancing": "DISABLED"
+        }
+    ],
+    "failures": []
+}
+
+
+---
+
+## ECS Task List
+
+{
+    "taskArns": []
+}
+
+
+---
+
+## ECS Task Details
+
+{
+    "tasks": [
+        {
+            "attachments": [
+                {
+                    "id": "f6b8c536-687e-4830-958e-5297fb962046",
+                    "type": "ElasticNetworkInterface",
+                    "status": "DELETED",
+                    "details": [
+                        {
+                            "name": "subnetId",
+                            "value": "subnet-0ae4088933d2b01c9"
+                        },
+                        {
+                            "name": "networkInterfaceId",
+                            "value": "eni-02a2ae245bf783ae0"
+                        },
+                        {
+                            "name": "macAddress",
+                            "value": "06:a7:75:bf:13:9a"
+                        },
+                        {
+                            "name": "privateDnsName",
+                            "value": "ip-172-31-41-248.ap-east-2.compute.internal"
+                        },
+                        {
+                            "name": "privateIPv4Address",
+                            "value": "172.31.41.248"
+                        }
+                    ]
+                }
+            ],
+            "attributes": [
+                {
+                    "name": "ecs.cpu-architecture",
+                    "value": "arm64"
+                }
+            ],
+            "availabilityZone": "ap-east-2a",
+            "clusterArn": "arn:aws:ecs:ap-east-2:807885433112:cluster/gemini-cli-cluster",
+            "connectivity": "CONNECTED",
+            "connectivityAt": "2025-09-03T10:04:31.354000+08:00",
+            "containerInstanceArn": "arn:aws:ecs:ap-east-2:807885433112:container-instance/gemini-cli-cluster/ae90364ae39b4d53aedf3e114350cbe9",
+            "containers": [
+                {
+                    "containerArn": "arn:aws:ecs:ap-east-2:807885433112:container/gemini-cli-cluster/b23e2cd65a99432190bd640cac2229b5/3b073717-124e-446d-bd79-8a4c19ccc3ab",
+                    "taskArn": "arn:aws:ecs:ap-east-2:807885433112:task/gemini-cli-cluster/b23e2cd65a99432190bd640cac2229b5",
+                    "name": "AppContainer",
+                    "image": "ghcr.io/neilkuan/ai-cli-demo:high-memory-server-v2",
+                    "imageDigest": "sha256:0f1805d9c5096f47c4c6faea739c9c51080452761a75c670adef6d28b7a6b77b",
+                    "runtimeId": "5b8e501a8a11757f875a14a31924a3093933e2aeb263cf5508b7a951c74a7ad9",
+                    "lastStatus": "STOPPED",
+                    "exitCode": 137,
+                    "reason": "OutOfMemoryError: Container killed due to memory usage",
+                    "networkBindings": [],
+                    "networkInterfaces": [
+                        {
+                            "attachmentId": "f6b8c536-687e-4830-958e-5297fb962046",
+                            "privateIpv4Address": "172.31.41.248"
+                        }
+                    ],
+                    "healthStatus": "UNKNOWN",
+                    "cpu": "256",
+                    "memory": "512"
+                }
+            ],
+            "cpu": "256",
+            "createdAt": "2025-09-03T10:04:31.354000+08:00",
+            "desiredStatus": "STOPPED",
+            "enableExecuteCommand": false,
+            "executionStoppedAt": "2025-09-03T10:05:12.529000+08:00",
+            "group": "service:gemini-cli-service",
+            "healthStatus": "UNKNOWN",
+            "lastStatus": "STOPPED",
+            "launchType": "EC2",
+            "memory": "512",
+            "overrides": {
+                "containerOverrides": [
+                    {
+                        "name": "AppContainer"
+                    }
+                ],
+                "inferenceAcceleratorOverrides": []
+            },
+            "pullStartedAt": "2025-09-03T10:04:44.743000+08:00",
+            "pullStoppedAt": "2025-09-03T10:04:45.200000+08:00",
+            "startedAt": "2025-09-03T10:04:44.816000+08:00",
+            "startedBy": "ecs-svc/7610517791682758113",
+            "stopCode": "EssentialContainerExited",
+            "stoppedAt": "2025-09-03T10:05:25.421000+08:00",
+            "stoppedReason": "Essential container in task exited",
+            "stoppingAt": "2025-09-03T10:05:12.975000+08:00",
+            "tags": [],
+            "taskArn": "arn:aws:ecs:ap-east-2:807885433112:task/gemini-cli-cluster/b23e2cd65a99432190bd640cac2229b5",
+            "taskDefinitionArn": "arn:aws:ecs:ap-east-2:807885433112:task-definition/gemini-cli-task-def:4",
+            "version": 6
+        }
+    ],
+    "failures": []
+}

--- a/gemini-cli/ops-chat/RECORD.lambda.md
+++ b/gemini-cli/ops-chat/RECORD.lambda.md
@@ -1,0 +1,145 @@
+# 查看 Lambda Function gemini-cli-lambda 最近幾次的執行狀態
+
+## 使用者請求
+
+查看 Lambda Function gemini-cli-lambda 最近幾次的執行狀態如何？ aws profile 使用 neil region ap-east-2 (思考過程跟，使用的 tools，分析結果記錄在 RECORD.lambda.md ）
+
+## 執行計畫
+
+1.  使用 AWS CLI 獲取 Lambda function 的日誌。
+2.  如果找不到日誌，請檢查 Lambda function 的名稱和設定。
+3.  分析日誌以確定最近的執行狀態。
+4.  將結果記錄在此檔案中。
+
+## 使用的工具和指令
+
+我最初嘗試使用以下指令來獲取日誌：
+
+```bash
+aws logs filter-log-events --log-group-name /aws/lambda/gemini-cli-lambda --start-time $(date -v-1d +%s)000 --profile neil --region ap-east-2
+```
+
+但這失敗了，因為日誌群組名稱不正確。
+
+然後我執行了以下指令來列出所有的 Lambda function，以確認正確的名稱和設定：
+
+```bash
+aws lambda list-functions --profile neil --region ap-east-2
+```
+
+執行結果顯示，日誌群組的名稱應該是 `gemini-cli-lambda`。
+
+最後，我使用以下指令成功獲取了日誌：
+
+```bash
+aws logs filter-log-events --log-group-name gemini-cli-lambda --profile neil --region ap-east-2
+```
+
+## 指令輸出 (日誌)
+
+```json
+{
+    "events": [
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861429982,
+            "message": "INIT_START Runtime Version: python:3.13.v60\tRuntime Version ARN: arn:aws:lambda:ap-east-2::runtime:6b9e6bdace9349e61d853adcfe031f7dbe39dd1762b0b2fcd6532dc5792399ca\n",
+            "ingestionTime": 1756861433135,
+            "eventId": "39179319099154731059779898332017085939947733016261165056"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861430053,
+            "message": "START RequestId: 1e5c8abd-3d36-461b-8c0f-a56b952715b3 Version: $LATEST\n",
+            "ingestionTime": 1756861433135,
+            "eventId": "39179319100738083968875572575066121937305766683185774593"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861430053,
+            "message": "Start to sleep 4s...\n",
+            "ingestionTime": 1756861433135,
+            "eventId": "39179319100738083968875572575066121937305766683185774594"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861433072,
+            "message": "END RequestId: 1e5c8abd-3d36-461b-8c0f-a56b952715b3\n",
+            "ingestionTime": 1756861433151,
+            "eventId": "39179319168064033723239523839381496494755457886699782144"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861433072,
+            "message": "REPORT RequestId: 1e5c8abd-3d36-461b-8c0f-a56b952715b3\tDuration: 3000.00 ms\tBilled Duration: 3068 ms\tMemory Size: 128 MB\tMax Memory Used: 35 MB\tInit Duration: 67.49 ms\tStatus: timeout\n",
+            "ingestionTime": 1756861433151,
+            "eventId": "39179319168064033723239523839381496494755457886699782145"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861434339,
+            "message": "START RequestId: 6960f94b-add0-473c-ab1a-f854a3f92817 Version: $LATEST\n",
+            "ingestionTime": 1756861437344,
+            "eventId": "39179319196319077889777823364776399652786435009419673600"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861434339,
+            "message": "Start to sleep 4s...\n",
+            "ingestionTime": 1756861437344,
+            "eventId": "39179319196319077889777823364776399652786435009419673601"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861437352,
+            "message": "END RequestId: 6960f94b-add0-473c-ab1a-f854a3f92817\n",
+            "ingestionTime": 1756861441605,
+            "eventId": "39179319263511223172950590895374574343871750050733555712"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861437352,
+            "message": "REPORT RequestId: 6960f94b-add0-473c-ab1a-f854a3f92817\tDuration: 3000.00 ms\tBilled Duration: 3000 ms\tMemory Size: 128 MB\tMax Memory Used: 35 MB\tStatus: timeout\n",
+            "ingestionTime": 1756861441605,
+            "eventId": "39179319263511223172950590895374574343871750050733555713"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861438600,
+            "message": "START RequestId: fb0d7393-ec96-48c3-a8a9-8bd8489822c5 Version: $LATEST\n",
+            "ingestionTime": 1756861441605,
+            "eventId": "39179319291342553180716808576011150748136905210197114882"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861438601,
+            "message": "Start to sleep 4s...\n",
+            "ingestionTime": 1756861441605,
+            "eventId": "39179319291364853925915339199152686466409553571703095299"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861441612,
+            "message": "END RequestId: fb0d7393-ec96-48c3-a8a9-8bd8489822c5\n",
+            "ingestionTime": 1756861441614,
+            "eventId": "39179319358512397718691045478327847245170201876906049536"
+        },
+        {
+            "logStreamName": "2025/09/02/gemini-cli-lambda[$LATEST]10681b291d2547ae90e38612e90b0aeb",
+            "timestamp": 1756861441612,
+            "message": "REPORT RequestId: fb0d7393-ec96-48c3-a8a9-8bd8489822c5\tDuration: 3000.00 ms\tBilled Duration: 3000 ms\tMemory Size: 128 MB\tMax Memory Used: 35 MB\tStatus: timeout\n",
+            "ingestionTime": 1756861441614,
+            "eventId": "39179319358512397718691045478327847245170201876906049537"
+        }
+    ],
+    "searchedLogStreams": []
+}
+```
+
+## 分析結論
+
+- **問題**: Lambda function `gemini-cli-lambda` 最近的執行全部都因為 **超時 (timeout)** 而失敗。
+- **根本原因**: Function 的超時時間設定為 3 秒，但其程式碼中包含一個 `sleep(4)` 的呼叫，試圖暫停 4 秒。由於執行時間超過了設定的超時時間，Lambda 服務終止了這個 function 的執行。
+- **建議**:
+    - 將 Lambda function 的超時時間增加到至少 4 秒以上。
+    - 或者，檢查程式碼邏輯，確定是否真的需要暫停 4 秒。

--- a/gemini-cli/ops-code/RECORD.ecs.fix.md
+++ b/gemini-cli/ops-code/RECORD.ecs.fix.md
@@ -1,0 +1,31 @@
+# ECS Task OutOfMemoryError Fix
+
+## Problem
+
+The ECS task was failing with an `OutOfMemoryError`. The container `AppContainer` was killed because it exceeded its memory limit.
+
+## Analysis
+
+I analyzed the `ops-chat/RECORD.ecs.md` file and found the following information in the "ECS Task Details" section:
+- The container `AppContainer` was stopped.
+- The `reason` for stopping is `OutOfMemoryError: Container killed due to memory usage`.
+- The `exitCode` is `137`.
+- The task `memory` is `512`.
+
+This indicated that the container was running out of memory.
+
+I then examined the CDK code in `ops-code/lib/gemini-cli-stack.ts` and found that the `memoryLimitMiB` was set to `512`.
+
+## Solution
+
+I increased the `memoryLimitMiB` from `512` to `1024` in `ops-code/lib/gemini-cli-stack.ts`.
+
+This change will allocate more memory to the ECS task and should resolve the `OutOfMemoryError`.
+
+## Deployment
+
+To apply the fix, I will run the following command from the `ops-code` directory:
+
+```bash
+cdk deploy --profile neil
+```

--- a/gemini-cli/ops-code/RECORD.lambda.fix.md
+++ b/gemini-cli/ops-code/RECORD.lambda.fix.md
@@ -1,0 +1,13 @@
+# 修復 Lambda Function 超時問題
+
+## 問題分析
+
+根據 `ops-chat/RECORD.lambda.md` 的日誌，Lambda function `gemini-cli-lambda` 持續因為超時而失敗。
+
+- **根本原因**: Function 的超時設定為 3 秒，但其程式碼中包含一個 `sleep(4)` 的呼叫，導致執行時間超過限制。
+- **解決方案**: 我將修改 CDK 程式碼，將 Lambda function 的超時時間增加到 10 秒。
+
+## 修復步驟
+
+1.  **修改 CDK 程式碼**: 編輯 `lib/gemini-cli-stack.ts` 檔案，將 `timeout` 屬性從 3 秒增加到 10 秒。
+2.  **部署變更**: 使用 `cdk deploy` 指令來應用更新。

--- a/gemini-cli/ops-code/lib/gemini-cli-stack.ts
+++ b/gemini-cli/ops-code/lib/gemini-cli-stack.ts
@@ -34,7 +34,7 @@ export class OpsCodeStack extends cdk.Stack {
     });
       taskDefinition.addContainer('AppContainer', {
         image: ecs.ContainerImage.fromRegistry('ghcr.io/neilkuan/ai-cli-demo:high-memory-server-v2'),
-        memoryLimitMiB: 512,
+        memoryLimitMiB: 1024,
         cpu: 256,
         logging: new ecs.AwsLogDriver({
           streamPrefix: 'gemini-cli',
@@ -52,6 +52,7 @@ export class OpsCodeStack extends cdk.Stack {
         functionName: 'gemini-cli-lambda',
         runtime: lambda.Runtime.PYTHON_3_13,
         handler: 'index.handler',
+        timeout: cdk.Duration.seconds(10),
         logGroup: new logs.LogGroup(this, 'LambdaLog', { logGroupName: 'gemini-cli-lambda', removalPolicy: cdk.RemovalPolicy.DESTROY}),
         code: new lambda.InlineCode(`
 import time


### PR DESCRIPTION
# ECS Task OutOfMemoryError Fix

## Problem

The ECS task was failing with an `OutOfMemoryError`. The container `AppContainer` was killed because it exceeded its memory limit.

## Analysis

I analyzed the `ops-chat/RECORD.ecs.md` file and found the following information in the "ECS Task Details" section:
- The container `AppContainer` was stopped.
- The `reason` for stopping is `OutOfMemoryError: Container killed due to memory usage`.
- The `exitCode` is `137`.
- The task `memory` is `512`.

This indicated that the container was running out of memory.

I then examined the CDK code in `ops-code/lib/gemini-cli-stack.ts` and found that the `memoryLimitMiB` was set to `512`.

## Solution

I increased the `memoryLimitMiB` from `512` to `1024` in `ops-code/lib/gemini-cli-stack.ts`.

This change will allocate more memory to the ECS task and should resolve the `OutOfMemoryError`.

## Deployment

To apply the fix, I will run the following command from the `ops-code` directory:

```bash
cdk deploy --profile neil
```

# 修復 Lambda Function 超時問題

## 問題分析

根據 `ops-chat/RECORD.lambda.md` 的日誌，Lambda function `gemini-cli-lambda` 持續因為超時而失敗。

- **根本原因**: Function 的超時設定為 3 秒，但其程式碼中包含一個 `sleep(4)` 的呼叫，導致執行時間超過限制。
- **解決方案**: 我將修改 CDK 程式碼，將 Lambda function 的超時時間增加到 10 秒。

## 修復步驟

1.  **修改 CDK 程式碼**: 編輯 `lib/gemini-cli-stack.ts` 檔案，將 `timeout` 屬性從 3 秒增加到 10 秒。
2.  **部署變更**: 使用 `cdk deploy` 指令來應用更新。


## 部署指令

```bash
cdk deploy --profile neil
```